### PR TITLE
Add empty scale-test-output folder for Locust to save output files. A…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Intellij
 .idea/
 *.iml
-# Avoid pushing scale test output
+# Avoid pushing scale test output but keep the gitkeep file
 scale-test-output/*
+!.gitkeep
 # Python
 __pycache__

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # amazon-emr-on-eks-scale-test-tool #
+Amazon EMR on EKS Scale Test tool allows users to submit sample/custom Spark jobs at scale to an EMR on EKS Virtual Cluster. 
+Users can customize the job and the job submission rate. The tool summarizes the results of the scale test in a CSV file containing information about every job submitted during test execution.
 
 ## Pre-requisites ##
 

--- a/scale-test-output/.gitkeep
+++ b/scale-test-output/.gitkeep
@@ -1,0 +1,4 @@
+# Keep this file to not ignore scale-test-output folder. 
+# All the files inside scale-test-output folder will be ignored by git
+# We need this folder upfront as Locust output files are saved at this filepath and
+# we cannot execute Locust test if this folder doesn't exist.


### PR DESCRIPTION
…dd Tool description in the README

*Issue #, if available:*

*Description of changes:*
- Add empty scale-test-output folder for Locust to save output files.
- Add Tool description in README file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
