### PR TITLE
Add cluster creation script and dependent resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 ## Pre-requisites ##
 
 ### Create a cluster for scale testing ###
-Amazon EKS is a managed service that makes it easy for you to run Kubernetes on AWS without needing to install, operate, and maintain your own Kubernetes control plane or nodes. 
-Follow the steps outlined in this document to create a new Kubernetes cluster with nodes in Amazon EKS.
-https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/setting-up-eks-cluster.html
+you can create a cluster that is configured for scaling by modifying the variables in `scripts/create_cluster_for_scale_test.sh` (eg cluster name and aws region) then running this script.
+You can skip this step if you already have a cluster setup for scale testing. After creating the cluster, take a look 
+at the (optional) additional manual configuration steps described in
+`resources/additional_cluster_configuration_steps.md`. `create_cluster_for_scale_test.sh` uses kubectl
+and eksctl, which can be installed using `installation.sh` (described below)
 
 ### Create Job Execution Role ###
-IAM role Arn to run workloads on Amazon EMR on EKS
 Steps to create Job execution role: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/creating-job-execution-role.html
+This is not necessary if you created a cluster using the `create_cluster_for_scale_test.sh` script because this script creates a job execution role and prints the ARN to stdout
 
 ### Setup Cloud9 Environment (This step is optional) ###
 
@@ -51,8 +53,8 @@ will also be printed on the console
    - EKS_CLUSTER_NAME
    - AWS REGION 
 1. Set the variables in `scale_test_tool/config/job_config_parameters.py` 
-   - JOB_EXECUTION_ROLE_ARN
-   - Various Job Config Parameters for running a custom job (Default configuration will run sample Spark Pi Job.)
+   - JOB_EXECUTION_ROLE_ARN, CLOUD_WATCH_LOG_GROUP_NAME, S3_LOG_PATH
+   - Optionally, override the various job config parameters in order to have the scale test run your own job. The default configuration will run the example SparkPi Job that is bundled with Spark.
 
 Configure the locust file at path `scale_test_tool/locust/locust.conf`:
 1. Configure ```users``` parameter based on the number of Jobs that should run as a part of scale test.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ and eksctl, which can be installed using `installation.sh` (described below)
 
 ### Create Job Execution Role ###
 Steps to create Job execution role: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/creating-job-execution-role.html
-This is not necessary if you created a cluster using the `create_cluster_for_scale_test.sh` script because this script creates a job execution role and prints the ARN to stdout
+This is not necessary if you created a cluster using the `create_cluster_for_scale_test.sh` script because this script creates a job execution role and prints the ARN to stdout.
+If you need to add permissions to the job execution role created by `create_cluster_for_scale_test.sh`, add the permissions to `resources/EMRContainers-JobExecutionRole.json`
 
 ### Setup Cloud9 Environment (This step is optional) ###
 

--- a/resources/EMRContainers-JobExecutionRole.json
+++ b/resources/EMRContainers-JobExecutionRole.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:*"
+            ]
+        }
+    ]
+}

--- a/resources/additional_cluster_configuration_steps.md
+++ b/resources/additional_cluster_configuration_steps.md
@@ -1,0 +1,17 @@
+# (optional) manual configuration steps once scale test cluster has been set up #
+
+## enable logs for coredns ##
+open the coredns configMap for editing:
+```
+kubectl edit configmap coredns -n kube-system
+```
+then add a line containing just the string "log" as shown in the snippet of the 
+configmap below:
+```
+data:
+   Corefile: |
+     .:53 {
+         log
+         errors
+         health
+```

--- a/resources/cluster-autoscaler-autodiscover.yaml
+++ b/resources/cluster-autoscaler-autodiscover.yaml
@@ -1,0 +1,179 @@
+# modified from https://github.com/kubernetes/autoscaler/blob/4e8994557002a42aeaa20a93465d5d52c15d2976/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
+# based on these instructions for installing cluster autoscaler: https://docs.aws.amazon.com/eks/latest/userguide/cluster-autoscaler.html
+# Do review these setup instructions (especially the Deployment Considerations sections) so that you understand the
+# basic concepts of the cluster autoscaler.
+# Do take a look at the latest version of this file in github and update this version of it locally, if necessary:
+# modified from https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# Before changing anything, take a look at the diff between this file and version in github that it was modified from.
+# If you create a cluster with a different version of kubernetes, you will have to modify this file to use the correct
+# container image for that kubernetes version (see cluster autoscaler setup instructions for more info).
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+  name: cluster-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["events", "endpoints"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["watch", "list", "get", "update"]
+  - apiGroups: [""]
+    resources:
+      - "pods"
+      - "services"
+      - "replicationcontrollers"
+      - "persistentvolumeclaims"
+      - "persistentvolumes"
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "replicasets", "daemonsets"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resourceNames: ["cluster-autoscaler"]
+    resources: ["leases"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create","list","watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+    verbs: ["delete", "get", "update", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-autoscaler
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-addon: cluster-autoscaler.addons.k8s.io
+    k8s-app: cluster-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: kube-system
+  labels:
+    app: cluster-autoscaler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8085'
+        cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+    spec:
+      serviceAccountName: cluster-autoscaler
+      containers:
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1
+          name: cluster-autoscaler
+          resources:
+            limits:
+              cpu: 100m
+              memory: 1100Mi
+            requests:
+              cpu: 100m
+              memory: 1100Mi
+          command:
+            - ./cluster-autoscaler
+            - --v=4
+            - --stderrthreshold=info
+            - --cloud-provider=aws
+            - --skip-nodes-with-local-storage=false
+            - --expander=least-waste
+            - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/MY_CLUSTER_NAME
+            - --balance-similar-node-groups
+            - --skip-nodes-with-system-pods=false
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs/ca-certificates.crt #/etc/ssl/certs/ca-bundle.crt for Amazon Linux Worker Nodes
+              readOnly: true
+          imagePullPolicy: "Always"
+      volumes:
+        - name: ssl-certs
+          hostPath:
+            path: "/etc/ssl/certs/ca-bundle.crt"

--- a/resources/cluster-autoscaler-autodiscover.yaml
+++ b/resources/cluster-autoscaler-autodiscover.yaml
@@ -3,7 +3,7 @@
 # Do review these setup instructions (especially the Deployment Considerations sections) so that you understand the
 # basic concepts of the cluster autoscaler.
 # Do take a look at the latest version of this file in github and update this version of it locally, if necessary:
-# modified from https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml
 # Before changing anything, take a look at the diff between this file and version in github that it was modified from.
 # If you create a cluster with a different version of kubernetes, you will have to modify this file to use the correct
 # container image for that kubernetes version (see cluster autoscaler setup instructions for more info).
@@ -149,7 +149,7 @@ spec:
     spec:
       serviceAccountName: cluster-autoscaler
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.19.1
+        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.0
           name: cluster-autoscaler
           resources:
             limits:

--- a/resources/cluster_in_new_VPC.yaml
+++ b/resources/cluster_in_new_VPC.yaml
@@ -1,8 +1,6 @@
 # notes:
 # - create_cluster_for_scale_test.sh replaces MY_CLUSTER_NAME, REGION, INSTANCE_TYPE, INSTANCE_SIZE with the configured
 #   values
-# todo:
-# - reduce permissions to the minimum needed for scale testing
 
 ---
 apiVersion: eksctl.io/v1alpha5
@@ -11,7 +9,7 @@ kind: ClusterConfig
 metadata:
   name: MY_CLUSTER_NAME
   region: REGION
-  version: "1.19"
+  version: "1.21"
 
 iam:
   withOIDC: true
@@ -54,14 +52,9 @@ nodeGroups:
       attachPolicyARNs:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
     preBootstrapCommands:
       # install ssm agent
       - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -92,14 +85,9 @@ nodeGroups:
       attachPolicyARNs:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
     preBootstrapCommands:
       # install ssm agent
       - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -130,14 +118,9 @@ nodeGroups:
       attachPolicyARNs:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
     preBootstrapCommands:
       # install ssm agent
       - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm

--- a/resources/cluster_in_new_VPC.yaml
+++ b/resources/cluster_in_new_VPC.yaml
@@ -1,0 +1,143 @@
+# notes:
+# - create_cluster_for_scale_test.sh replaces MY_CLUSTER_NAME, REGION, INSTANCE_TYPE, INSTANCE_SIZE with the configured
+#   values
+# todo:
+# - reduce permissions to the minimum needed for scale testing
+
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: MY_CLUSTER_NAME
+  region: REGION
+  version: "1.19"
+
+iam:
+  withOIDC: true
+  serviceAccounts:
+  - metadata:
+      name: cluster-autoscaler
+      namespace: kube-system
+    wellKnownPolicies:
+      autoScaler: true
+
+cloudWatch:
+  clusterLogging:
+    enableTypes: ["*"]
+
+nodeGroups:
+  - name: ng-INSTANCE_TYPE-INSTANCE_SIZE-1a
+    privateNetworking: true # if only 'Private' subnets are given, this must be enabled
+    labels: { nodegroup-label: ng-INSTANCE_TYPE-INSTANCE_SIZE-1a }
+    instanceType: INSTANCE_TYPE.INSTANCE_SIZE
+    minSize: 1
+    maxSize: 1000
+    desiredCapacity: 1
+    volumeSize: 100
+    availabilityZones: ["REGIONa"]
+    asgMetricsCollection:
+      - granularity: 1Minute
+        metrics: # note this is not the full set of ASG metrics that can be collected
+          - GroupDesiredCapacity
+          - GroupInServiceInstances
+          - GroupPendingInstances
+          - GroupStandbyInstances
+          - GroupTerminatingInstances
+          - GroupTotalInstances
+    tags:
+      k8s.io/cluster-autoscaler/enabled: "true" # required for autoscaler autodiscovery to work
+      k8s.io/cluster-autoscaler/MY_CLUSTER_NAME: "owned" # required for autoscaler autodiscovery to work
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    preBootstrapCommands:
+      # install ssm agent
+      - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  - name: ng-INSTANCE_TYPE-INSTANCE_SIZE-1b
+    privateNetworking: true # if only 'Private' subnets are given, this must be enabled
+    labels: { nodegroup-label: ng-INSTANCE_TYPE-INSTANCE_SIZE-1b } # this allows you to schedule spark jobs on specific nodegroups
+    instanceType: INSTANCE_TYPE.INSTANCE_SIZE
+    minSize: 1
+    maxSize: 1000
+    desiredCapacity: 1
+    volumeSize: 100
+    availabilityZones: ["REGIONb"]
+    asgMetricsCollection:
+      - granularity: 1Minute
+        metrics: # note this is not the full set of ASG metrics that can be collected
+          - GroupDesiredCapacity
+          - GroupInServiceInstances
+          - GroupPendingInstances
+          - GroupStandbyInstances
+          - GroupTerminatingInstances
+          - GroupTotalInstances
+    tags:
+      k8s.io/cluster-autoscaler/enabled: "true" # required for autoscaler autodiscovery to work
+      k8s.io/cluster-autoscaler/MY_CLUSTER_NAME: "owned" # required for autoscaler autodiscovery to work
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    preBootstrapCommands:
+      # install ssm agent
+      - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  - name: ng-INSTANCE_TYPE-INSTANCE_SIZE-1c
+    privateNetworking: true # if only 'Private' subnets are given, this must be enabled
+    labels: { nodegroup-label: ng-INSTANCE_TYPE-INSTANCE_SIZE-1c }
+    instanceType: INSTANCE_TYPE.INSTANCE_SIZE
+    minSize: 1
+    maxSize: 1000
+    desiredCapacity: 1
+    volumeSize: 100
+    availabilityZones: ["REGIONc"]
+    asgMetricsCollection:
+      - granularity: 1Minute
+        metrics: # note this is not the full set of ASG metrics that can be collected
+          - GroupDesiredCapacity
+          - GroupInServiceInstances
+          - GroupPendingInstances
+          - GroupStandbyInstances
+          - GroupTerminatingInstances
+          - GroupTotalInstances
+    tags:
+      k8s.io/cluster-autoscaler/enabled: "true" # required for autoscaler autodiscovery to work
+      k8s.io/cluster-autoscaler/MY_CLUSTER_NAME: "owned" # required for autoscaler autodiscovery to work
+    iam:
+      withAddonPolicies:
+        autoScaler: true
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+        - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEC2FullAccess
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/CloudWatchFullAccess
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    preBootstrapCommands:
+      # install ssm agent
+      - yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm

--- a/resources/dns-horizontal-autoscaler.yaml
+++ b/resources/dns-horizontal-autoscaler.yaml
@@ -1,0 +1,114 @@
+# modified from https://github.com/kubernetes/kubernetes/blob/f59523ab4c85381f8c4a80ee7c9c9c080f7f67e2/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# based on these setup instructions: https://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/
+# do take a look at the latest version of this file in github and update this version of it locally, if necessary:
+# https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# Before changing anything, take a look at the diff between this file and version in github that it was modified from.
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kube-dns-autoscaler
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: kube-dns-autoscaler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-dns-autoscaler
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns-autoscaler
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-dns-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns-autoscaler
+    spec:
+      priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        supplementalGroups: [ 65534 ]
+        fsGroup: 65534
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - name: autoscaler
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.8.1
+        resources:
+            requests:
+                cpu: "20m"
+                memory: "10Mi"
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace=kube-system
+          - --configmap=kube-dns-autoscaler
+          # Should keep target in sync with cluster/addons/dns/kube-dns.yaml.base
+          - --target=Deployment/coredns
+          # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+          # If using small nodes, "nodesPerReplica" should dominate.
+          - --default-params={"linear":{"coresPerReplica":100,"nodesPerReplica":10,"preventSinglePointFailure":true,"includeUnschedulableNodes":true}}
+          - --logtostderr=true
+          - --v=2
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      serviceAccountName: kube-dns-autoscaler

--- a/resources/emr-trust-policy.json
+++ b/resources/emr-trust-policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "elasticmapreduce.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/resources/fluent-bit.yaml
+++ b/resources/fluent-bit.yaml
@@ -1,0 +1,367 @@
+# taken from https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/e1d9571c8648e8614a6af729e2ae415399ae12b4/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+# You may want to replace this with the latest version of the file which you can find here:
+# https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-role
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - pods/logs
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-role
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                     5
+        Log_Level                 info
+        Daemon                    off
+        Parsers_File              parsers.conf
+        HTTP_Server               ${HTTP_SERVER}
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 ${HTTP_PORT}
+        storage.path              /var/fluent-bit/state/flb-storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+
+    @INCLUDE application-log.conf
+    @INCLUDE dataplane-log.conf
+    @INCLUDE host-log.conf
+
+  application-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Path                /var/log/containers/*.log
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_container.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/fluent-bit*
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_log.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/cloudwatch-agent*
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  cwagent_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_cwagent.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                kubernetes
+        Match               application.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_Tag_Prefix     application.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
+        Labels              Off
+        Annotations         Off
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               application.*
+        region              ${AWS_REGION}
+        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
+        log_stream_prefix   ${HOST_NAME}-
+        auto_create_group   true
+        extra_user_agent    container-insights
+
+  dataplane-log.conf: |
+    [INPUT]
+        Name                systemd
+        Tag                 dataplane.systemd.*
+        Systemd_Filter      _SYSTEMD_UNIT=docker.service
+        Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
+        DB                  /var/fluent-bit/state/systemd.db
+        Path                /var/log/journal
+        Read_From_Tail      ${READ_FROM_TAIL}
+
+    [INPUT]
+        Name                tail
+        Tag                 dataplane.tail.*
+        Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_dataplane_tail.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                modify
+        Match               dataplane.systemd.*
+        Rename              _HOSTNAME                   hostname
+        Rename              _SYSTEMD_UNIT               systemd_unit
+        Rename              MESSAGE                     message
+        Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+    [FILTER]
+        Name                aws
+        Match               dataplane.*
+        imds_version        v1
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               dataplane.*
+        region              ${AWS_REGION}
+        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
+        log_stream_prefix   ${HOST_NAME}-
+        auto_create_group   true
+        extra_user_agent    container-insights
+
+  host-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 host.dmesg
+        Path                /var/log/dmesg
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_dmesg.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 host.messages
+        Path                /var/log/messages
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_messages.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+        Name                tail
+        Tag                 host.secure
+        Path                /var/log/secure
+        Parser              syslog
+        DB                  /var/fluent-bit/state/flb_secure.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+        Name                aws
+        Match               host.*
+        imds_version        v1
+
+    [OUTPUT]
+        Name                cloudwatch_logs
+        Match               host.*
+        region              ${AWS_REGION}
+        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
+        log_stream_prefix   ${HOST_NAME}.
+        auto_create_group   true
+        extra_user_agent    container-insights
+
+  parsers.conf: |
+    [PARSER]
+        Name                docker
+        Format              json
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+        Name                syslog
+        Format              regex
+        Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key            time
+        Time_Format         %b %d %H:%M:%S
+
+    [PARSER]
+        Name                container_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+        Name                cwagent_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: amazon/aws-for-fluent-bit:2.10.0
+        imagePullPolicy: Always
+        env:
+            - name: AWS_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: logs.region
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: cluster.name
+            - name: HTTP_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.server
+            - name: HTTP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.port
+            - name: READ_FROM_HEAD
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.head
+            - name: READ_FROM_TAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.tail
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CI_VERSION
+              value: "k8s/1.3.8"
+        resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 500m
+              memory: 100Mi
+        volumeMounts:
+        # Please don't change below read-only permissions
+        - name: fluentbitstate
+          mountPath: /var/fluent-bit/state
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: runlogjournal
+          mountPath: /run/log/journal
+          readOnly: true
+        - name: dmesg
+          mountPath: /var/log/dmesg
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: fluentbitstate
+        hostPath:
+          path: /var/fluent-bit/state
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
+      - name: dmesg
+        hostPath:
+          path: /var/log/dmesg
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/scripts/create_cluster_for_scale_test.sh
+++ b/scripts/create_cluster_for_scale_test.sh
@@ -1,0 +1,119 @@
+# this script uses eksctl to create an EKS cluster in a new VPC and configures it so that it can be used for scale
+# testing. There are a few additional but optional manual configuration steps explained in
+# additional_cluster_configuration_steps.md.
+# One of the things this script installs on the EKS cluster is fluent bit, which writes all pod logs to cloudwatch
+# logs under 3 log groups with prefix /aws/containerinsights/${CLUSTER_NAME}.
+# EKS also writes logs of system pods to cloudwatch log group
+# /aws/eks/${CLUSTER_NAME} https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
+# todo
+# - recommendation for reading this closely
+# - note that the execution role will be printed at the end of the script
+# - better list of what the script does
+# - some scripts point to yaml files that are not the latest
+set -eu -o pipefail
+
+# change these variables according to your needs ====================================================================
+CLUSTER_NAME=
+# aws region in which to create the cluster
+REGION=
+INSTANCE_TYPE=m5
+INSTANCE_SIZE=xlarge
+# if you intend to scale the cluster quickly to more than a few dozen nodes, it is recommended to put the fluent bit
+# image in ECR then set this variable to the URI of the fluent bit image in ECR. If this variable is set, the
+# script uses this ECR image. If the variable is not set, the script does not modify the fluent bit yaml file, which
+# means the fluent bit image is pulled from Dockerhub (which can result in being throttled if the cluster is scaling up
+# quickly). To put the image in ECR, pull it from Dockerhub then push it to an ECR repo in your AWS account.
+FLUENT_BIT_ECR_IMAGE=
+# The following are reasonable CNI settings. CNI_MINIMUM_IP_TARGET should be increased if you run scale tests with
+# higher pod density. More info about these settings: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/eni-and-ip-target.md
+# If the subnets created by eksctl still do not provide enough addresses (by default eksctl creates a "/19" subnet which
+# contains ~8.1k addresses for each nodegroup), you can configure CNI to take addresses from (larger) subnets that you create
+# by following https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
+CNI_MINIMUM_IP_TARGET=7
+CNI_WARM_IP_TARGET=2
+# ===================================================================================================================
+
+SCRIPT_FOLDER=$(dirname "$0")
+BASE_FOLDER=$(dirname "$SCRIPT_FOLDER")
+
+EMR_ON_EKS_JOB_EXECUTION_ROLE=$CLUSTER_NAME-job-execution-role
+
+# create job execution role per: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/creating-job-execution-role.html
+EMR_ON_EKS_JOB_EXECUTION_ROLE_ARN=$(aws iam create-role --role-name $EMR_ON_EKS_JOB_EXECUTION_ROLE \
+--assume-role-policy-document "file://${BASE_FOLDER}/resources/emr-trust-policy.json" \
+--query 'Role.Arn')
+echo "created job execution role with ARN $EMR_ON_EKS_JOB_EXECUTION_ROLE_ARN"
+aws iam put-role-policy --role-name $EMR_ON_EKS_JOB_EXECUTION_ROLE \
+--policy-name EMR-Containers-Job-Execution \
+--policy-document "file://${BASE_FOLDER}/resources/EMRContainers-JobExecutionRole.json"
+
+
+# create the cluster
+echo "going to create EKS cluster $CLUSTER_NAME"
+sed "s/REGION/$REGION/g; s/MY_CLUSTER_NAME/$CLUSTER_NAME/g; s/INSTANCE_TYPE/$INSTANCE_TYPE/g; s/INSTANCE_SIZE/$INSTANCE_SIZE/g" \
+$BASE_FOLDER/resources/cluster_in_new_VPC.yaml \
+|  eksctl create cluster -f -
+
+# update trust policy of the IAM role that was just created so that it can be used with all namespaces of this cluster.
+# It would be cleaner to do this on a per-namespace basis (instead of "*") but that would require creating a new
+# IAM role for every namespace because only 4 namespaces can be associated with an IAM role because IAM roles have a
+# character limit on the size of trust policies.
+aws emr-containers update-role-trust-policy \
+    --cluster-name $CLUSTER_NAME \
+    --role-name $EMR_ON_EKS_JOB_EXECUTION_ROLE \
+    --namespace "*" \
+    --region $REGION
+
+echo "going to install cluster autoscaler"
+# install dns-autoscaler. READ THE COMMENTS AT THE TOP OF resources/cluster-autoscaler-autodiscover.yaml
+sed "s/MY_CLUSTER_NAME/$CLUSTER_NAME/g" $BASE_FOLDER/resources/cluster-autoscaler-autodiscover.yaml \
+| kubectl apply -f -
+
+echo "going to install fluent bit"
+# install fluent bit per https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html
+kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
+ClusterName=$CLUSTER_NAME
+RegionName=$REGION
+FluentBitHttpPort='2020'
+FluentBitReadFromHead='Off'
+[[ ${FluentBitReadFromHead} = 'On' ]] && FluentBitReadFromTail='Off'|| FluentBitReadFromTail='On'
+[[ -z ${FluentBitHttpPort} ]] && FluentBitHttpServer='Off' || FluentBitHttpServer='On'
+kubectl create configmap fluent-bit-cluster-info \
+--from-literal=cluster.name=${ClusterName} \
+--from-literal=http.server=${FluentBitHttpServer} \
+--from-literal=http.port=${FluentBitHttpPort} \
+--from-literal=read.head=${FluentBitReadFromHead} \
+--from-literal=read.tail=${FluentBitReadFromTail} \
+--from-literal=logs.region=${RegionName} -n amazon-cloudwatch
+
+if [ -n "${FLUENT_BIT_ECR_IMAGE}" ]; then
+   yq e "select(.kind == \"DaemonSet\" and .metadata.name == \"fluent-bit\").spec.template.spec.containers.[].image |= \"${FLUENT_BIT_ECR_IMAGE}\"" $BASE_FOLDER/resources/fluent-bit.yaml \
+   | kubectl apply -f -
+else
+   kubectl apply -f $BASE_FOLDER/resources/fluent-bit.yaml
+fi
+
+echo "going to install dns autoscaler"
+# install dns-autoscaler. READ THE COMMENTS AT THE TOP OF resources/dns-horizontal-autoscaler.yaml
+kubectl apply -f $BASE_FOLDER/resources/dns-horizontal-autoscaler.yaml
+
+echo "going to install kubernetes dashboard"
+# install kubernetes dashboard
+# instructions for viewing the dashboard in your browser: https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
+
+echo "going to install cni metrics helper"
+# install CNI metrics helper, which sends to cloudwatch metrics about IP address usage, ENI usage, and CNI errors
+# https://docs.aws.amazon.com/eks/latest/userguide/cni-metrics-helper.html
+# Note: the metrics published to cloudwatch will have a dimension called CLUSTER_ID whose value includes--in addition
+# to the cluster name--the name of the nodegroup of the node that the cni-metrics-helper deployment is running on.
+# But the metrics published are for the entire cluster, not just whichever nodegroup the deployment ends up on.
+# This means that during the life of a cluster, the metric may be published using different dimension values if the
+# cni-metrics-helper pod terminates and is started up again in a different nodegroup
+# The node roles must have the cloudwatch:PutMetricData permission for this to work
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.7/cni-metrics-helper.yaml
+
+kubectl set env daemonset aws-node -n kube-system MINIMUM_IP_TARGET=$CNI_MINIMUM_IP_TARGET
+kubectl set env daemonset aws-node -n kube-system WARM_IP_TARGET=$CNI_WARM_IP_TARGET
+
+echo "ARN of job execution role created by this script: $EMR_ON_EKS_JOB_EXECUTION_ROLE_ARN"

--- a/scripts/create_cluster_for_scale_test.sh
+++ b/scripts/create_cluster_for_scale_test.sh
@@ -9,6 +9,8 @@
 #   prefix /aws/containerinsights/${CLUSTER_NAME}. It can be very useful to have all pod logs available in cloudwatch
 #   when doing scale testing. EKS also writes logs of system pods to cloudwatch log group /aws/eks/${CLUSTER_NAME}
 #   more info: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
+#   If you want to collect metrics for resources such as CPU, memory, disk, and network, follow these steps for setting
+#   up Container Insights: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html
 # - installs cluster-autoscaler
 # - installs kubernetes dashboard
 # - installs dns-autoscaler


### PR DESCRIPTION
*Description of changes:*
these commits add a script for creating an EKS cluster that is configured for scaling `create_cluster_for_scale_test.sh`. Note that the following files were copied from github and only minor modifications were made:
* `cluster-autoscaler-autodiscover.yaml`
* `dns-horizontal-autoscaler.yaml`
* `fluent-bit.yaml`

These commits also include some changes to the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
